### PR TITLE
resolve unconfirmed subscriber issue.

### DIFF
--- a/src/web/modules/custom/workbc_tr_content_mail/workbc_tr_content_mail.module
+++ b/src/web/modules/custom/workbc_tr_content_mail/workbc_tr_content_mail.module
@@ -38,6 +38,7 @@ function workbc_tr_content_mail_entity_update(Drupal\Core\Entity\EntityInterface
         $database = \Drupal::database();
         $query = $database->select('simplenews_subscriber', 's');
         $query = $query->fields('s', array('mail'))
+          ->condition('s.status','1','=')
           ->condition('s_sub.deleted', '0')
           ->condition('s_sub.subscriptions_target_id','resource_newsletter');
         $query->join('simplenews_subscriber__subscriptions', 's_sub', 's.id = s_sub.entity_id');
@@ -75,11 +76,14 @@ function workbc_tr_content_mail_entity_update(Drupal\Core\Entity\EntityInterface
         if(!empty($subscribers)) {
           foreach ( $subscribers as $subscriber ) {
             $s = Subscriber::loadByMail($subscriber);
+            if (!$s) {
+              continue;
+            }
             $sm_data = [
               'newsletter' => $newsletter,
               'simplenews_subscriber' => $s,
             ];
-  
+
             //Create string from unsubscribe-url token
             $unsubscribed_url = \Drupal::token()->replace('[simplenews-subscriber:unsubscribe-url]', $sm_data);
             //Get Resource title


### PR DESCRIPTION
The original error was caused by a module update removing the `subscriptions_status` from the `simplenews_subscriber__subscriptions` table.  In fixing this issue I failed to realize that a `status` field was added to the `simplenews_subscriber` table.  This status field is used to indicate if the subscriber has confirmed their email address.  In DEV and TEST there were no unconfirmed subscribers, in PROD there are and the custom module was picking up these subscribers because we were no longer filtering them out. `Subscriber::loadByMail($subscriber)` returns `false` for these subscribers and in turn `\Drupal::token()->replace('[simplenews-subscriber:unsubscribe-url]', $sm_data)` fails.

I have added back a condition to the query checking the `simplenews_subscriber.stats` field.

In addition, I added a check when the list of subscribers is being processed to ignore any subscribers that return 'false'