### PR TITLE
[WBCAMS-1697] add custom template to resolve alert center issue.

### DIFF
--- a/src/web/themes/custom/bcgov_teachers/templates/modules/sitewide-alert.html.twig
+++ b/src/web/themes/custom/bcgov_teachers/templates/modules/sitewide-alert.html.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file sitewide_alert.html.twig
+ * Default theme implementation to present Sitewide Alert data.
+ *
+ * This template is used when viewing Sitewide Alert messages.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element. This should contain the `data-uuid` attribute needed for
+ *   the loading to work.
+ * - uuid: The UUID of the sitewide alert.
+ * - is_dismissible: True if this alert is dismissable, false otherwise.
+ * - style: The alert style.
+ * - style_class: A style class derived from the style.
+ * - sitewide_alert: The sitewide alert entity.
+ *
+ * @see template_preprocess_sitewide_alert()
+ *
+ * @ingroup themeable
+ */
+#}
+<div {{ attributes }} role="alert">
+  {% if content -%}
+    <div>{{- content -}}</div>
+  {%- endif %}
+  {% if is_dismissible -%}
+  {# The dismiss (close) button must have the class js-dismiss-button in order to work. #}
+    <button class="close js-dismiss-button" aria-label="{{ 'close'|t }}">
+      <span aria-hidden="true">×</span>
+    </button>
+  {%- endif %}
+</div>


### PR DESCRIPTION
The css is expecting a 'div' instead of a 'span'.  Rather than changing the ccs I copied the custom `sitewide-alert.html.twig` template from workbc-main so both projects are using the identical approach. In addition, the copied template has an accessibility update.
